### PR TITLE
Updated conda requirements for boost

### DIFF
--- a/conda-recipe/n88util/meta.yaml
+++ b/conda-recipe/n88util/meta.yaml
@@ -13,12 +13,12 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - cmake >=3.1.0
-    - boost >=1.56,<=1.67
+    - cmake >=3.2
+    - boost >=1.57,<=1.67
     - ninja
     - gtest
   run:
-    - boost >=1.56
+    - boost >=1.57,<=1.67
 
 about:
   home: https://github.com/Numerics88/n88util


### PR DESCRIPTION
Just making the conda build and run requirements consistent for aimio, n88util and pqctio.