### PR TITLE
CMake updates to improve package import/export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if (WIN32)
     add_definitions (-DBOOST_ALL_NO_LIB)
 endif()
 
-include_directories (${Boost_INCLUDE_DIR})
+include_directories (${Boost_INCLUDE_DIRS})
 include_directories ("${CMAKE_SOURCE_DIR}/include")
 # The following is for n88util_version.h
 include_directories ("${PROJECT_BINARY_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ endforeach()
 
 # Add all targets to the build-tree export set
 export (TARGETS n88util
+    NAMESPACE n88util::
     FILE "${PROJECT_BINARY_DIR}/n88utilTargets.cmake")
 
 # Export the package for use from the build-tree

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ include (GenerateExportHeader)
 add_library (n88util ${SRC})
 set_target_properties(n88util 
     PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
         VERSION ${N88UTIL_VERSION}
         SOVERSION ${N88UTIL_MAJOR_VERSION}.${N88UTIL_MINOR_VERSION})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories ("${GTEST_INCLUDE_DIR}")
+include_directories (${GTEST_INCLUDE_DIRS})
 include_directories ("${CMAKE_CURRENT_SOURCE_DIR}/../include")
 
 set (SRC


### PR DESCRIPTION
This includes the following changes:

1. Add NAMESPACE to the export for the build tree
2. Use Boost\_INCLUDE\_DIRS according to current FindBoost documentation
3. Use GTEST\_INCLUDE\_DIRS according to current FindGTest documentation
4. Force POSITION\_INDEPENDENT\_CODE (i.e. even for static libraries)

The NAMESPACE had been omitted from the export for the build tree, though it was present for the export for the install tree.  Now the namespace is consistently applied.

For both Boost and googletest, CMake currently specifies that \_INCLUDE\_DIRS (rather than \_INCLUDE_DIR) should be used to get the include directories.  This is because the includes for these packages might be split across multiple directories, depending on how they have been installed.

The POSITION\_INDEPENDENT\_CODE property is necessary for static libraries that might eventually be linked with other code into a shared object (.so, .dylib, .dll).  In this case, consumers of the static library will be linking it into a Python extension module.